### PR TITLE
Add some documentation about getting started in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Paper proof Lean widget
 
+To get started with development, you will need to run these commands first:
+
+```bash
+cd widget
+yarn install
+```
+
 For development run `yarn dev` in command line (it will watch changes in widget ts files and automatically rebuild). Development requires [watchexec](https://watchexec.github.io/), which can be installed by running `cargo install watchexec-cli` if you have Rust toolchain available.
 
 Run `lean4.restartFile` from VSCode when in Lean file to pick up a new widget version.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Paper proof Lean widget
 
-For development run `yarn dev` in command line (it will watch changes in widget ts files and automatically rebuild).
+For development run `yarn dev` in command line (it will watch changes in widget ts files and automatically rebuild). Development requires [watchexec](https://watchexec.github.io/), which can be installed by running `cargo install watchexec-cli` if you have Rust toolchain available.
+
 Run `lean4.restartFile` from VSCode when in Lean file to pick up a new widget version.


### PR DESCRIPTION
In particular, add a comment on getting necessary `watchexec` tool and running `yarn install` in the right directory.