### PR TITLE
Made it so that if you work in the browser you only need to run 1 thing insead of 2 things

### DIFF
--- a/PaperProof.lean
+++ b/PaperProof.lean
@@ -73,17 +73,21 @@ def getPpContext (params : GetPpContextParams) : RequestM (RequestTask String) :
       return "No top level type"
 
 @[widget]
-def ppWidget: UserWidgetDefinition := {
+def paperProofApi: UserWidgetDefinition := {
+  name := "Paper proof API"
+  javascript:= include_str "widget" / "dist" / "extensionAsApi.js"
+}
+
+@[widget]
+def paperProof: UserWidgetDefinition := {
   name := "Paper proof"
   javascript:= include_str "widget" / "dist" / "indexExtension.js"
 }
 
-structure PaperProofProps where
-  kind : String
-  deriving ToJson, FromJson, Inhabited
+-- Use this if you want to look at localhost:3000
+#widget paperProofApi .null
 
-def forBrowser := (toJson { kind := "browser" : PaperProofProps})
-#widget ppWidget forBrowser
+-- Use this if you want to look at VSCode webview
+-- #widget paperProof .null
 
 -- antonkov: For tests go to Example.lean
--- #widget ppWidget (toJson { kind := "extension" : PaperProofProps})

--- a/README.md
+++ b/README.md
@@ -36,11 +36,8 @@ Now, you would usually want to develop the extension in the browser, there is ju
 
 First, do `cd widget` and run `yarn install`. Then:
 
-- `yarn run watchBrowser` - this compiles the browser app.
-- `node server.cjs` - this starts the node server that 1. memorizes the `InfoTree` information that the browser app then queries 2. renders the browser app at http://localhost:3000.
-- `yarn run buildExtension` - this builds the VsCode extension once - we need this because someone needs to send the `InfoTree` information to `server.cjs`. If you prefer copypasting your `InfoTree`s you can do without it.
-
-With this setup, you don't need to manually rebuild anything (unless you touch `indexExtension.tsx`, which you should need to do rarely if ever).
+- `yarn run watchBrowser` - this compiles both the browser app and the reduced version of the vscode extension (this reduced version just sends `InfoTree`s to our node server as you hover over the lines in a proof).
+- `node server.cjs` - this starts the node server that 1. memorizes the `InfoTree` information that the browser app then queries 2. renders the browser app at http://localhost:3000..
 
 ### Develop while looking at the VSCode extension
 

--- a/widget/rollup.config.js
+++ b/widget/rollup.config.js
@@ -69,17 +69,30 @@ export default (cliArgs) => {
   // - we could add it to the browser app via `<script type="module"/>`, but that would require externalizing ["react", "react-dom", "@leanprover/infoview"] somehow and I didn't want to google how to set this up. ALSO we would want 2 separate source files either way - one for browser, `indexBrowser.tsx` (that mounts the react component to out localhost:3000 html page); and one for the vscode extension, `indexExtension.tsx` (that just exports the react component). ALSO - sourcemaps, as described below!
 
   if (cliArgs.configBrowser) {
-    return {
-      input: [`src/indexBrowser.tsx`],
-      output: {
-        dir: "dist",
-        format: "iife",
-        // Hax: apparently setting `global` makes some CommonJS modules work ¯\_(ツ)_/¯
-        intro: "const global = window",
-        sourcemap: true,
+    return [
+      {
+        input: `src/indexBrowser.tsx`, 
+        output: {
+          file: 'dist/indexBrowser.js',
+          format: 'iife',
+          // Hax: apparently setting `global` makes some CommonJS modules work ¯\_(ツ)_/¯
+          intro: "const global = window",
+          sourcemap: true,
+        },
+        plugins
       },
-      plugins,
-    };
+      {
+        input: `src/extensionAsApi.tsx`,
+        output: {
+          file: 'dist/extensionAsApi.js',
+          format: "es",
+          intro: "const global = window",
+          sourcemap: false,
+        },
+        external: ["react", "react-dom", "@leanprover/infoview"],
+        plugins
+      },
+    ]
   } else {
     return {
       input: [`src/indexExtension.tsx`],

--- a/widget/src/extensionAsApi.tsx
+++ b/widget/src/extensionAsApi.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import { useContext, useEffect, useState } from "react";
 import { EditorContext, RpcContext, useAsync } from "@leanprover/infoview";
 import { Location } from "vscode-languageserver-protocol";
-import App from "./tldraw_stuff/App";
 
 export default function () {
   const editorConnection = useContext(EditorContext);
   const rs = useContext(RpcContext);
   const [location, setLocation] = useState<Location | undefined>(undefined);
+  const [serverError, setServerError] = useState(null);
 
   useEffect(() => {
     return editorConnection.events.changedCursorLocation.on((loc) => {
@@ -22,15 +22,36 @@ export default function () {
     const context = await rs.call("getPpContext", {
       pos: location.range.start,
     });
+
+    setServerError(null);
+    await fetch("http://localhost:3000/sendTypes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: context as string,
+    }).catch((error) => {
+      setServerError(serverError);
+    });
+
     return context;
   }, [location]);
+
+  if (serverError) {
+    return <div>Server error: {anyToString(serverError)}</div>;
+  }
 
   if (response.state === "loading") {
     return <div>Loading...</div>;
   } else if (response.state === "rejected") {
     return <div>Error: {anyToString(response.error)}</div>;
   } else {
-    return <App proofTree={JSON.parse(response.value)} />;
+    return (
+      <section>
+        <h2>Just sent this InfoTree to the node server:</h2>
+        <pre>
+          <code>{response.value}</code>
+        </pre>
+      </section>
+    );
   }
 }
 


### PR DESCRIPTION
If you develop in the browser, and, therefore, only touch the code that affect the browser (either helper vscode extension code or tldraw code) - then you only ever need to run `yarn run watchBrowser` and `node server.cjs`.

If you develop in vscode - then you only ever need to run `yarn run watchExtension`.

Not a single thought was contributed to file names (`extensionAsApi.tsx`? `indexBrowser.tsx`?), should be changed to something else eventually.

I could have made it so that everything is bundled at the same time, but was worried about recompile times? Might be premature optimization; will be clear as we develop. I don't think we need to be switching a lot between the develop-in-vscode and develop-in-browser modes, so recompile time is probably more important than the absence of need to run 2 scripts.